### PR TITLE
Hide viewmodel while in vehicle

### DIFF
--- a/addons/sourcemod/gamedata/vehicles.txt
+++ b/addons/sourcemod/gamedata/vehicles.txt
@@ -18,15 +18,20 @@
 				"linux"		"4"
 				"windows"	"4"
 			}
-			"CBaseServerVehicle::HandlePassengerExit"
+			"CBaseServerVehicle::SetPassenger"
 			{
-				"linux"		"18"
-				"windows"	"18"
+				"linux"		"9"
+				"windows"	"9"
 			}
 			"CBaseServerVehicle::HandleEntryExitFinish"
 			{
 				"linux"		"22"
 				"windows"	"22"
+			}
+			"CBaseServerVehicle::GetDriver"
+			{
+				"linux"		"60"
+				"windows"	"60"
 			}
 			"CBaseAnimating::StudioFrameAdvance"
 			{
@@ -59,6 +64,24 @@
 					"move"
 					{
 						"type"	"int"
+					}
+				}
+			}
+			"CBaseServerVehicle::SetPassenger"
+			{
+				"offset"	"CBaseServerVehicle::SetPassenger"
+				"hooktype"	"raw"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"nRole"
+					{
+						"type"	"int"
+					}
+					"pPassenger"
+					{
+						"type"	"cbaseentity"
 					}
 				}
 			}


### PR DESCRIPTION
This was actually quite tricky to pull off since I didn't want to hide the viewmodel in yet another client `Think` function, potentially overriding other stuff.
The vehicle itself also didn't have enough information for me, as the `m_hPlayer` pointer was null once you have exited the vehicle and thus couldn't be used to reset the viewmodel on exit.

Solved it through a raw virtual `CBaseServerVehicle::SetPassenger` hook, in the same fashion how the crosshair is hidden in server code. Since we need to get the driver through the server vehicle, an SDKCall to `CBaseServerVehicle::GetDriver` is needed too.