### PR TITLE
Disable entry and exit animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 This is a plugin that allows spawning driveable vehicles based on `prop_vehicle_driveable` in Team Fortress 2.
 
-While this has surely been done before, the implementation of this plugin is vastly different. Instead of simulating
-user input on the vehicle through the entity I/O system, it forwards your user input directly to the vehicle, making
-driving feel incredibly smooth.
+While this has surely been done before, the implementation of this plugin is vastly different. Instead of simulating user input on
+the vehicle through the entity inputs, it forwards your user input directly to the vehicle, making driving feel incredibly smooth.
 
 This plugin bundles the required entity fixes and a few configurable nice-to-have features.
 
@@ -14,7 +13,7 @@ This plugin bundles the required entity fixes and a few configurable nice-to-hav
 * Vehicle sounds
 * Entry and exit animations (experimental)
 * Physics collisions and damage against other players
-* Highly customizable through plugin configuration and ConVars
+* High customizability through plugin configuration and ConVars
 
 ## Dependencies
 
@@ -25,26 +24,26 @@ This plugin bundles the required entity fixes and a few configurable nice-to-hav
 ## Installation
 
 1. Download the latest version from the [releases](https://github.com/Mikusch/tf-vehicles/releases) page
-2. Extract the contents of the archive into your server directory
+2. Extract the contents of the ZIP file into your server's `tf` directory
 3. Restart your server or type `sm plugins load vehicles` into your server console
 
 ## Usage
 
 There is a menu combining all of the plugin's features that can be accessed using `sm_vehicle`.
 
-Additionally, you may use `sm_createvehicle` to create and `sm_removevehicle` to remove a vehicle. To remove all
-vehicles in the map, use `sm_removeallvehicles`.
+Additionally, you may use `sm_createvehicle` to create and `sm_removevehicle` to remove a vehicle. To remove all vehicles in the
+map, use `sm_removeallvehicles`.
 
 ## Configuration
 
-The vehicle configuration allows you to add your own vehicles. Each vehicle requires at least a name, model, vehicle
-script, and vehicle type. More documentation and examples can be found in
+The vehicle configuration allows you to add custom vehicles. Each vehicle requires at least a name, model, vehicle script, and
+vehicle type. More documentation and examples can be found in
 the [default configuration](/addons/sourcemod/configs/vehicles/vehicles.cfg).
 
 To learn how to create custom vehicle models and scripts, check out
 the [Vehicle Scripts for Source](https://steamcommunity.com/sharedfiles/filedetails/?id=1373837962) guide on Steam.
 
-**Example:**
+### Example Configuration
 
 ```
 "Vehicles"
@@ -85,17 +84,17 @@ The plugin creates the following console variables:
 
 This plugin will automatically enable physics collisions and damage to allow vehicles to collide with other players.
 
-If you intend to use these vehicles in a friendly environment without any combat aspects, set `sv_turbophysics` to `1`.
-It will allow vehicles to pass through other players.
+If you intend to use these vehicles in a friendly environment without any combat aspects, set `sv_turbophysics` to `1`. It will
+allow vehicles to pass through other players.
 
 ## Entry and Exit Animations
 
-Most vehicles have entry and exit animations that make the player "transition" from one point to another, which are
-fully supported by the plugin.
+Most vehicles have entry and exit animations that make the player transition between the vehicle and the entry/exit points. The plugin
+fully supports these animations.
 
-However, since Valve probably never intended `prop_vehicle_driveable` to be used outside of Half-Life 2, there is code
-that does not function properly in a multiplayer environment and can even cause client crashes.
+However, since Valve never intended `prop_vehicle_driveable` to be used outside of Half-Life 2, there is code that does not
+function properly in a multiplayer environment and can even cause client crashes.
 
-Because of this, entry and exit animations on all vehicles are disabled by default and have to be manually enabled by
+Because of that, entry and exit animations on all vehicles are disabled by default and have to be manually enabled by
 setting `tf_vehicle_enable_entry_exit_anims` to `1`. If you intend to use this plugin on a public server, it is **highly
-recommended** to keep this disabled.
+recommended** to keep the animations disabled.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The plugin creates the following console variables:
   in/sec
 * `tf_vehicle_physics_damage_modifier ( def. "1.0" )` - Modifier of impact-based physics damage against other
   players
-* `tf_vehicle_voicemenu_use ( def. "1" )` - Whether the 'MEDIC!' voice menu command will call +use
+* `tf_vehicle_voicemenu_use ( def. "1" )` - Allow the 'MEDIC!' voice menu command to call +use
+* `tf_vehicle_enable_entry_exit_anims ( def. "0" )` - Enable entry and exit animations (experimental, use at your own risk!)
 
 ## Physics Damage
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin bundles the required entity fixes and a few configurable nice-to-hav
 
 * Fully functioning driveable vehicles based on `prop_vehicle_driveable`
 * Vehicle sounds
-* Entry and exit animations
+* Entry and exit animations (experimental)
 * Physics collisions and damage against other players
 * Highly customizable through plugin configuration and ConVars
 
@@ -76,12 +76,10 @@ the [Vehicle Scripts for Source](https://steamcommunity.com/sharedfiles/filedeta
 
 The plugin creates the following console variables:
 
-* `tf_vehicle_lock_speed ( def. "10.0" )` - Vehicle must be going slower than this for player to enter or exit, in
-  in/sec
-* `tf_vehicle_physics_damage_modifier ( def. "1.0" )` - Modifier of impact-based physics damage against other
-  players
+* `tf_vehicle_lock_speed ( def. "10.0" )` - Vehicle must be going slower than this for player to enter or exit, in in/sec
+* `tf_vehicle_physics_damage_modifier ( def. "1.0" )` - Modifier of impact-based physics damage against other players
 * `tf_vehicle_voicemenu_use ( def. "1" )` - Allow the 'MEDIC!' voice menu command to call +use
-* `tf_vehicle_enable_entry_exit_anims ( def. "0" )` - Enable entry and exit animations (experimental, use at your own risk!)
+* `tf_vehicle_enable_entry_exit_anims ( def. "0" )` - Enable entry and exit animations (experimental!)
 
 ## Physics Damage
 
@@ -89,3 +87,15 @@ This plugin will automatically enable physics collisions and damage to allow veh
 
 If you intend to use these vehicles in a friendly environment without any combat aspects, set `sv_turbophysics` to `1`.
 It will allow vehicles to pass through other players.
+
+## Entry and Exit Animations
+
+Most vehicles have entry and exit animations that make the player "transition" from one point to another, which are
+fully supported by the plugin.
+
+However, since Valve probably never intended `prop_vehicle_driveable` to be used outside of Half-Life 2, there is code
+that does not function properly in a multiplayer environment and can even cause client crashes.
+
+Because of this, entry and exit animations on all vehicles are disabled by default and have to be manually enabled by
+setting `tf_vehicle_enable_entry_exit_anims` to `1`. If you intend to use this plugin on a public server, it is **highly
+recommended** to keep this disabled.

--- a/addons/sourcemod/gamedata/vehicles.txt
+++ b/addons/sourcemod/gamedata/vehicles.txt
@@ -28,6 +28,11 @@
 				"linux"		"10"
 				"windows"	"10"
 			}
+			"CBaseServerVehicle::GetExitAnimToUse"
+			{
+				"linux"		"21"
+				"windows"	"21"
+			}
 			"CBaseServerVehicle::HandleEntryExitFinish"
 			{
 				"linux"		"22"
@@ -87,6 +92,24 @@
 					"pPassenger"
 					{
 						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CBaseServerVehicle::GetExitAnimToUse"
+			{
+				"offset"	"CBaseServerVehicle::GetExitAnimToUse"
+				"hooktype"	"raw"
+				"return"	"int"
+				"this"		"address"
+				"arguments"
+				{
+					"vecEyeExitEndpoint"
+					{
+						"type"	"vectorptr"
+					}
+					"bAllPointsBlocked"
+					{
+						"type"	"bool"
 					}
 				}
 			}

--- a/addons/sourcemod/gamedata/vehicles.txt
+++ b/addons/sourcemod/gamedata/vehicles.txt
@@ -6,7 +6,6 @@
 		{
 			"CTFPlayerMove::SetupMove"
 			{
-				"library"	"server"
 				"linux"		"@_ZN13CTFPlayerMove9SetupMoveEP11CBasePlayerP8CUserCmdP11IMoveHelperP9CMoveData"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x10\x56\x8B\x75\x08\x89\x4D\xFC"
 			}
@@ -18,6 +17,11 @@
 				"linux"		"4"
 				"windows"	"4"
 			}
+			"CBaseServerVehicle::GetVehicleEnt"
+			{
+				"linux"		"8"
+				"windows"	"8"
+			}
 			"CBaseServerVehicle::SetPassenger"
 			{
 				"linux"		"9"
@@ -27,6 +31,11 @@
 			{
 				"linux"		"10"
 				"windows"	"10"
+			}
+			"CBaseServerVehicle::HandlePassengerEntry"
+			{
+				"linux"		"17"
+				"windows"	"17"
 			}
 			"CBaseServerVehicle::GetExitAnimToUse"
 			{
@@ -47,6 +56,11 @@
 			{
 				"linux"		"194"
 				"windows"	"193"
+			}
+			"CBasePlayer::GetInVehicle"
+			{
+				"linux"		"397"
+				"windows"	"396"
 			}
 		}
 		"Functions"
@@ -92,6 +106,24 @@
 					"pPassenger"
 					{
 						"type"	"cbaseentity"
+					}
+				}
+			}
+			"CBaseServerVehicle::HandlePassengerEntry"
+			{
+				"offset"	"CBaseServerVehicle::HandlePassengerEntry"
+				"hooktype"	"raw"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"pPassenger"
+					{
+						"type"	"cbaseentity"
+					}
+					"bAllowEntryOutsideZone"
+					{
+						"type"	"bool"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -241,7 +241,7 @@ public void OnMapStart()
 	{
 		SDKHook(vehicle, SDKHook_Think, PropVehicleDriveable_Think);
 		
-		DHookVehicle(vehicle);
+		DHookVehicle(GetServerVehicle(vehicle));
 	}
 }
 
@@ -635,8 +635,8 @@ public void PropVehicleDriveable_Spawn(int vehicle)
 
 public void PropVehicleDriveable_SpawnPost(int vehicle)
 {
-	//m_pServerVehicle is initialized in CPropVehicleDriveable::Spawn
-	DHookVehicle(vehicle);
+	//m_pServerVehicle is initialized in Spawn so we hook it in SpawnPost
+	DHookVehicle(GetServerVehicle(vehicle));
 	
 	SetEntPropFloat(vehicle, Prop_Data, "m_flMinimumSpeedToEnterExit", tf_vehicle_lock_speed.FloatValue);
 }
@@ -791,10 +791,8 @@ DynamicHook CreateDynamicHook(GameData gamedata, const char[] name)
 	return hook;
 }
 
-void DHookVehicle(int vehicle)
+void DHookVehicle(Address serverVehicle)
 {
-	Address serverVehicle = GetServerVehicle(vehicle);
-	
 	if (g_DHookSetPassenger != null)
 		g_DHookSetPassenger.HookRaw(Hook_Pre, serverVehicle, DHookCallback_SetPassengerPre);
 	

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -828,18 +828,17 @@ public MRESReturn DHookCallback_HandlePassengerEntryPre(Address serverVehicle, D
 {
 	if (!tf_vehicle_enable_entry_exit_anims.BoolValue)
 	{
-		/*
-		 * Vehicle entry animations do not work properly in a multiplayer environment
-		 * and the logic of CBaseServerVehicle::HandlePassengerEntry doesn't allow us to easily disable them.
-		 *
-		 * Superceding the original function and running our own logic is the most sane thing to do.
-		 */
-		
 		int client = params.Get(1);
-		SDKCall_GetInVehicle(client, serverVehicle, VEHICLE_ROLE_DRIVER);
-		SetEntProp(SDKCall_GetVehicleEnt(serverVehicle), Prop_Data, "m_bEnterAnimOn", true);
+		int vehicle = SDKCall_GetVehicleEnt(serverVehicle);
 		
-		return MRES_Supercede;
+		//This saves us an SDKCall to CPropVehicleDriveable::CanEnterVehicle
+		if (GetEntPropEnt(vehicle, Prop_Data, "m_hPlayer") == client)
+			return MRES_Supercede;
+		
+		//I don't know why we need to set this but entering vehicles doesn't work if we don't (client-side code?)
+		SetEntProp(vehicle, Prop_Data, "m_bEnterAnimOn", true);
+		
+		SDKCall_GetInVehicle(client, serverVehicle, VEHICLE_ROLE_DRIVER);
 	}
 	
 	return MRES_Ignored;

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -635,6 +635,7 @@ public void PropVehicleDriveable_Spawn(int vehicle)
 
 public void PropVehicleDriveable_SpawnPost(int vehicle)
 {
+	//m_pServerVehicle is initialized in CPropVehicleDriveable::Spawn
 	DHookVehicle(vehicle);
 	
 	SetEntPropFloat(vehicle, Prop_Data, "m_flMinimumSpeedToEnterExit", tf_vehicle_lock_speed.FloatValue);
@@ -794,7 +795,6 @@ void DHookVehicle(int vehicle)
 {
 	Address serverVehicle = GetServerVehicle(vehicle);
 	
-	//m_pServerVehicle is initialized in CPropVehicleDriveable::Spawn
 	if (g_DHookSetPassenger != null)
 		g_DHookSetPassenger.HookRaw(Hook_Pre, serverVehicle, DHookCallback_SetPassengerPre);
 	

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.5.0"
+#define PLUGIN_VERSION	"1.6.0"
 #define PLUGIN_AUTHOR	"Mikusch"
 #define PLUGIN_URL		"https://github.com/Mikusch/tf-vehicles"
 

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -280,7 +280,7 @@ public void OnEntityDestroyed(int entity)
 		return;
 	
 	if (IsEntityVehicle(entity))
-		SDKCall_HandleEntryExitFinish(entity, true, true);
+		SDKCall_HandleEntryExitFinish(GetServerVehicle(entity), true, true);
 }
 
 //-----------------------------------------------------------------------------
@@ -608,7 +608,7 @@ public void PropVehicleDriveable_Think(int vehicle)
 			}
 		}
 		
-		SDKCall_HandleEntryExitFinish(vehicle, exitAnimOn, true);
+		SDKCall_HandleEntryExitFinish(GetServerVehicle(vehicle), exitAnimOn, true);
 	}
 }
 
@@ -819,7 +819,7 @@ public MRESReturn DHookCallback_SetupMovePre(DHookParam params)
 		Address helper = params.Get(3);
 		Address move = params.Get(4);
 		
-		SDKCall_VehicleSetupMove(vehicle, client, ucmd, helper, move);
+		SDKCall_VehicleSetupMove(GetServerVehicle(vehicle), client, ucmd, helper, move);
 	}
 }
 
@@ -961,14 +961,10 @@ Handle PrepSDKCall_GetInVehicle(GameData gamedata)
 	return call;
 }
 
-void SDKCall_VehicleSetupMove(int vehicle, int client, Address ucmd, Address helper, Address move)
+void SDKCall_VehicleSetupMove(Address serverVehicle, int client, Address ucmd, Address helper, Address move)
 {
 	if (g_SDKCallVehicleSetupMove != null)
-	{
-		Address serverVehicle = GetServerVehicle(vehicle);
-		if (serverVehicle != Address_Null)
-			SDKCall(g_SDKCallVehicleSetupMove, serverVehicle, client, ucmd, helper, move);
-	}
+		SDKCall(g_SDKCallVehicleSetupMove, serverVehicle, client, ucmd, helper, move);
 }
 
 int SDKCall_GetVehicleEnt(Address serverVehicle)
@@ -979,14 +975,10 @@ int SDKCall_GetVehicleEnt(Address serverVehicle)
 	return -1;
 }
 
-void SDKCall_HandleEntryExitFinish(int vehicle, bool exitAnimOn, bool resetAnim)
+void SDKCall_HandleEntryExitFinish(Address serverVehicle, bool exitAnimOn, bool resetAnim)
 {
 	if (g_SDKCallHandleEntryExitFinish != null)
-	{
-		Address serverVehicle = GetServerVehicle(vehicle);
-		if (serverVehicle != Address_Null)
-			SDKCall(g_SDKCallHandleEntryExitFinish, serverVehicle, exitAnimOn, resetAnim);
-	}
+		SDKCall(g_SDKCallHandleEntryExitFinish, serverVehicle, exitAnimOn, resetAnim);
 }
 
 int SDKCall_GetDriver(Address serverVehicle)

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -155,7 +155,7 @@ public void OnPluginStart()
 	tf_vehicle_lock_speed = CreateConVar("tf_vehicle_lock_speed", "10.0", "Vehicle must be going slower than this for player to enter or exit, in in/sec", _, true, 0.0);
 	tf_vehicle_physics_damage_modifier = CreateConVar("tf_vehicle_physics_damage_modifier", "1.0", "Modifier of impact-based physics damage against other players", _, true, 0.0);
 	tf_vehicle_voicemenu_use = CreateConVar("tf_vehicle_voicemenu_use", "1", "Allow the 'MEDIC!' voice menu command to call +use");
-	tf_vehicle_enable_entry_exit_anims = CreateConVar("tf_vehicle_enable_entry_exit_anims", "0", "Enable entry and exit animations (experimental, use at your own risk!)");
+	tf_vehicle_enable_entry_exit_anims = CreateConVar("tf_vehicle_enable_entry_exit_anims", "0", "Enable entry and exit animations (experimental!)");
 	
 	RegAdminCmd("sm_vehicle", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);
 	RegAdminCmd("sm_vehicles", ConCmd_OpenVehicleMenu, ADMFLAG_GENERIC);


### PR DESCRIPTION
Closes #9 

This PR aims to improve the stability and compatibility of the plugin by disabling entry and exit animations, which are known to cause camera issues and even client crashes.

Can be toggled using `tf_vehicle_enable_entry_exit_anims ( def. "0" )` but by doing that you are essentially opening Pandora's box.

This isn't perfect, as the view snapping still occurs sometimes but I am convinced that issue can not be fixed.