### PR TITLE
Fix view snapping on vehicle entry

### DIFF
--- a/addons/sourcemod/gamedata/vehicles.txt
+++ b/addons/sourcemod/gamedata/vehicles.txt
@@ -9,6 +9,11 @@
 				"linux"		"@_ZN13CTFPlayerMove9SetupMoveEP11CBasePlayerP8CUserCmdP11IMoveHelperP9CMoveData"
 				"windows"	"\x55\x8B\xEC\x83\xEC\x10\x56\x8B\x75\x08\x89\x4D\xFC"
 			}
+			"CBasePlayer::CanEnterVehicle"
+			{
+				"linux"		"@_ZN11CBasePlayer15CanEnterVehicleEP14IServerVehiclei"
+				"windows"	"\x55\x8B\xEC\x56\x57\x8B\x7D\x08\x8B\xF1\xFF\x75\x0C"
+			}
 		}
 		"Offsets"
 		{

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -26,7 +26,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"1.6.0"
+#define PLUGIN_VERSION	"1.6.1"
 #define PLUGIN_AUTHOR	"Mikusch"
 #define PLUGIN_URL		"https://github.com/Mikusch/tf-vehicles"
 

--- a/addons/sourcemod/scripting/vehicles.sp
+++ b/addons/sourcemod/scripting/vehicles.sp
@@ -250,7 +250,6 @@ public void OnMapStart()
 
 public void OnClientPutInServer(int client)
 {
-	SDKHook(client, SDKHook_PostThink, Client_PostThink);
 	SDKHook(client, SDKHook_OnTakeDamage, Client_OnTakeDamage);
 	g_ClientInUse[client] = false;
 }
@@ -581,25 +580,6 @@ public Action ConCmd_DestroyAllVehicles(int client, int args)
 //-----------------------------------------------------------------------------
 // SDKHooks
 //-----------------------------------------------------------------------------
-
-public void Client_PostThink(int client)
-{
-	if (GetEntPropEnt(client, Prop_Send, "m_hVehicle") != -1)
-	{
-		static bool clientCanExit[MAXPLAYERS + 1];
-		
-		//Player needs to release IN_USE before they can exit the vehicle
-		if (GetEntProp(client, Prop_Data, "m_afButtonReleased") & IN_USE)
-			clientCanExit[client] = true;
-		
-		//For some reason IN_USE never gets assigned to m_afButtonPressed inside vehicles, preventing exiting, so let's add it ourselves
-		if (GetClientButtons(client) & IN_USE && clientCanExit[client])
-		{
-			SetEntProp(client, Prop_Data, "m_afButtonPressed", GetEntProp(client, Prop_Data, "m_afButtonPressed") | IN_USE);
-			clientCanExit[client] = false;
-		}
-	}
-}
 
 public Action Client_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {


### PR DESCRIPTION
Follow-up to #10

Turns out it **is** possible to disable the view snapping, at the cost of entering the vehicle at an arbitrary angle. This is miles better than untouchable client-side code, so I'll take it.